### PR TITLE
CI/CD with Github Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,7 +26,8 @@ pnpm-debug.log*
 
 # local-only files
 *.local
-docker-compose.override.yaml
 
 # Docker build files
 Dockerfile
+docker-compose.yaml
+docker-compose.*.yaml

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Trigger the workflow every time you push to the `main` branch
+  # Using a different branch name? Replace `main` with your branch’s name
+  push:
+    branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab on GitHub.
+  workflow_dispatch:
+
+# Allow this job to clone the repo and create a page deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    env:
+      BUILD_ENV: ci
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Build static site
+        run: make cibuild
+      - name: Upload static site as artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ pnpm-debug.log*
 # local-only files
 *.local
 docker-compose.override.yaml
+docker-compose.dev.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ FROM dev AS build
 
 COPY . .
 
-RUN ["scripts/build"]
+CMD ["sleep", "infinity"]

--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,57 @@
+BUILD_ENV ?= dev
+
+COMPOSE_TEMPLATE_FILE := docker-compose.template.yaml
+COMPOSE_OVERRIDE_FILE := docker-compose.$(BUILD_ENV).yaml
+COMPOSE_FLAGS := -f docker-compose.yaml -f $(COMPOSE_OVERRIDE_FILE)
+COMPOSE := docker compose $(COMPOSE_FLAGS)
+
+# Ensure COMPOSE_OVERRIDE_FILE exists if it is included in COMPOSE_FLAGS
+COMPOSE_TARGETS := $(word 2,$(findstring $(strip -f $(COMPOSE_OVERRIDE_FILE)),$(strip $(COMPOSE_FLAGS))))
+$(COMPOSE_OVERRIDE_FILE):
+	cp $(COMPOSE_TEMPLATE_FILE) $(COMPOSE_OVERRIDE_FILE)
+
 .PHONY: build
-build:
-	docker compose build
+build: $(COMPOSE_TARGETS)
+	$(COMPOSE) build
 
 .PHONY: up
 up: build
-	docker compose up --detach
+	$(COMPOSE) up --detach
 
 .PHONY: down
-down:
-	docker compose down --remove-orphans
+down: $(COMPOSE_TARGETS)
+	$(COMPOSE) down --remove-orphans
 
 .PHONY: clean
-clean:
-	docker compose down --remove-orphans --volumes
+clean: $(COMPOSE_TARGETS)
+	$(COMPOSE) down --remove-orphans --volumes
 	rm -rf dist
 	rm -rf node_modules
 
 .PHONY: status
-status:
-	docker compose ps --all
+status: $(COMPOSE_TARGETS)
+	$(COMPOSE) ps --all
 
 .PHONY: shell
 shell: up
-	docker compose exec web bash
+	$(COMPOSE) exec web bash
 
 .PHONY: bootstrap
 bootstrap: up
-	docker compose exec web scripts/bootstrap
+	$(COMPOSE) exec web scripts/bootstrap
 
 .PHONY: update
 update: up
-	docker compose exec web scripts/update
+	$(COMPOSE) exec web scripts/update
 
 .PHONY: setup
 setup: up
-	docker compose exec web scripts/setup
+	$(COMPOSE) exec web scripts/setup
 
 .PHONY: test
 test: up
-	docker compose exec web scripts/test
+	$(COMPOSE) exec web scripts/test
 
 .PHONY: cibuild
 cibuild: up
-	docker compose exec web scripts/cibuild
+	$(COMPOSE) exec web scripts/cibuild

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -1,0 +1,7 @@
+services:
+  web:
+    volumes:
+      - ./dist:/opt/app/dist
+volumes:
+  npm_cache:
+  node_modules:

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -2,6 +2,3 @@ services:
   web:
     volumes:
       - ./dist:/opt/app/dist
-volumes:
-  npm_cache:
-  node_modules:

--- a/docker-compose.template.yaml
+++ b/docker-compose.template.yaml
@@ -1,0 +1,13 @@
+services:
+  web:
+    build:
+      target: dev
+    ports:
+      - 127.0.0.1:4321:4321
+    volumes:
+      - .:/opt/app
+      - npm_cache:/root/.npm
+      - node_modules:/opt/app/node_modules
+volumes:
+  npm_cache:
+  node_modules:


### PR DESCRIPTION
This PR configures GitHub Actions to:

- Build the site using the `make cibuild` entrypoint
- Upload the site as a build artifact to GitHub
- Deploy the uploaded artifact to GitHub Pages